### PR TITLE
[TM-27] [BE] [NEW] Add Dummy Data for TPO

### DIFF
--- a/app/Http/Controllers/ChartController.php
+++ b/app/Http/Controllers/ChartController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\AmbientTemperature;
 use App\Models\ApparentPower;
 use App\Models\Current;
 use App\Models\Frequency;
@@ -9,10 +10,13 @@ use App\Models\IHD;
 use App\Models\IHDVoltage;
 use App\Models\KFactor;
 use App\Models\Metric;
+use App\Models\OilLevel;
 use App\Models\Power;
 use App\Models\PowerFactor;
 use App\Models\PowerLoss;
+use App\Models\Pressure;
 use App\Models\ReactivePower;
+use App\Models\Temperature;
 use App\Models\THDCurrent;
 use App\Models\THDVoltage;
 use App\Models\Trafo;
@@ -160,10 +164,31 @@ class ChartController extends Controller
 
     public function getChartTPO($trafoId, $date) {
         $trafo = Trafo::find($trafoId);
+        $temperatures = Temperature::where('trafo_id', $trafoId)
+            ->orderBy('created_at', 'desc')
+            ->limit(12)
+            ->get();
+        $pressures = Pressure::where('trafo_id', $trafoId)
+            ->orderBy('created_at', 'desc')
+            ->limit(12)
+            ->get();
+        $oilLevels = OilLevel::where('trafo_id', $trafoId)
+            ->orderBy('created_at', 'desc')
+            ->limit(12)
+            ->get();
+        $ambientTemperatures = AmbientTemperature::where('trafo_id', $trafoId)
+            ->orderBy('created_at', 'desc')
+            ->limit(12)
+            ->get();
 
         return Inertia::render('Chart/ChartTPO', [
             'trafo' => $trafo,
             'date' => $date,
+            'title' => 'Chart TPO',
+            'temperatures' => $temperatures,
+            'pressures' => $pressures,
+            'oilLevels' => $oilLevels,
+            'ambientTemperatures' => $ambientTemperatures,
         ]);
     }
 

--- a/app/Http/Controllers/MetricController.php
+++ b/app/Http/Controllers/MetricController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\AmbientTemperature;
 use App\Models\ApparentPower;
 use App\Models\Current;
 use App\Models\Frequency;
@@ -11,10 +12,13 @@ use App\Models\IHDVoltage;
 use App\Models\IndividualHarmonicDistortion;
 use App\Models\KFactor;
 use App\Models\Metric;
+use App\Models\OilLevel;
 use App\Models\Power;
 use App\Models\PowerFactor;
 use App\Models\PowerLoss;
+use App\Models\Pressure;
 use App\Models\ReactivePower;
+use App\Models\Temperature;
 use App\Models\THD;
 use App\Models\THDCurrent;
 use App\Models\THDFrequency;
@@ -105,10 +109,20 @@ class MetricController extends Controller
 
     public function getMetricTPO($trafoId, $date) {
         $trafo = Trafo::find($trafoId);
+        $temperatures = Temperature::where('trafo_id', $trafoId)->whereDate('created_at', $date)->get();
+        $pressures = Pressure::where('trafo_id', $trafoId)->whereDate('created_at', $date)->get();
+        $oilLevels = OilLevel::where('trafo_id', $trafoId)->whereDate('created_at', $date)->get();
+        $ambientTemperatures = AmbientTemperature::where('trafo_id', $trafoId)->whereDate('created_at', $date)->get();
 
         return Inertia::render('Metric/MetricTPO', [
             'trafo' => $trafo,
             'date' => $date,
+            'title' => 'Metric TPO',
+            'chartRoute' => 'chart.tpo',
+            'temperatures' => $temperatures,
+            'pressures' => $pressures,
+            'oilLevels' => $oilLevels,
+            'ambientTemperatures' => $ambientTemperatures
         ]);
     }
 

--- a/app/Http/Controllers/TrafoController.php
+++ b/app/Http/Controllers/TrafoController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Temperature;
 use App\Models\Trafo;
 use App\Models\Voltage;
 use Illuminate\Http\Request;
@@ -12,7 +13,7 @@ class TrafoController extends Controller
 {
     public function showWithDates($id) {
         $trafo = Trafo::find($id);
-        $dates = Voltage::selectRaw('DATE(created_at) as date')
+        $dates = Temperature::selectRaw('DATE(created_at) as date')
             ->where('trafo_id', $id)
             ->groupBy(DB::raw('DATE(created_at)'))
             ->get();

--- a/app/Http/Controllers/TrafoController.php
+++ b/app/Http/Controllers/TrafoController.php
@@ -13,7 +13,7 @@ class TrafoController extends Controller
 {
     public function showWithDates($id) {
         $trafo = Trafo::find($id);
-        $dates = Temperature::selectRaw('DATE(created_at) as date')
+        $dates = Voltage::selectRaw('DATE(created_at) as date')
             ->where('trafo_id', $id)
             ->groupBy(DB::raw('DATE(created_at)'))
             ->get();

--- a/app/Models/AmbientTemperature.php
+++ b/app/Models/AmbientTemperature.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AmbientTemperature extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/OilLevel.php
+++ b/app/Models/OilLevel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class OilLevel extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Pressure.php
+++ b/app/Models/Pressure.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Pressure extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Temperature.php
+++ b/app/Models/Temperature.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Temperature extends Model
+{
+    use HasFactory;
+}

--- a/database/migrations/2024_09_21_120806_create_temperatures_table.php
+++ b/database/migrations/2024_09_21_120806_create_temperatures_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('temperatures', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('trafo_id');
+            $table->string('topic_name');
+            $table->double('temperature');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('temperatures');
+    }
+};

--- a/database/migrations/2024_09_21_121946_create_pressures_table.php
+++ b/database/migrations/2024_09_21_121946_create_pressures_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pressures', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('trafo_id');
+            $table->string('topic_name');
+            $table->double('pressure');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pressures');
+    }
+};

--- a/database/migrations/2024_09_21_121954_create_oil_levels_table.php
+++ b/database/migrations/2024_09_21_121954_create_oil_levels_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oil_levels', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('trafo_id');
+            $table->string('topic_name');
+            $table->double('oil_level');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oil_levels');
+    }
+};

--- a/database/migrations/2024_09_21_122006_create_ambient_temperatures_table.php
+++ b/database/migrations/2024_09_21_122006_create_ambient_temperatures_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ambient_temperatures', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('trafo_id');
+            $table->string('topic_name');
+            $table->double('ambient_temperature');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ambient_temperatures');
+    }
+};

--- a/resources/js/Components/Metric/GaugeGroup.tsx
+++ b/resources/js/Components/Metric/GaugeGroup.tsx
@@ -3,7 +3,13 @@ import {Gauge, gaugeClasses} from "@mui/x-charts";
 import {Stack, Typography} from "@mui/material";
 import { amber, green, red, yellow } from "@mui/material/colors";
 
-export default function GaugeGroup({gauges, labels}: GaugeGroupProps) {
+export default function GaugeGroup({
+                                       gauges,
+                                       labels,
+                                       isOverride = false,
+                                       upperSafeThreshold = 51,
+                                       lowerSafeThreshold = 49,
+                                   }: GaugeGroupProps) {
     function colorPercentage({
         minValue,
         value,
@@ -21,6 +27,13 @@ export default function GaugeGroup({gauges, labels}: GaugeGroupProps) {
             return amber[300];
         }
         return red[300];
+    }
+
+    function colorThreshold(value: number) {
+        if (value >= lowerSafeThreshold && value <= upperSafeThreshold) {
+            return green[300];
+        }
+        return amber[300];
     }
 
     return <Stack
@@ -42,7 +55,7 @@ export default function GaugeGroup({gauges, labels}: GaugeGroupProps) {
                     valueMax={Math.max(...gauge)}
                     sx={(theme) => ({
                         [`& .${gaugeClasses.valueArc}`]: {
-                          fill: colorPercentage({
+                          fill: isOverride ? colorThreshold(gauge[gauge.length - 1] || 0) : colorPercentage({
                             minValue: Math.min(...gauge),
                             value: gauge[gauge.length - 1],
                             maxValue: Math.max(...gauge),

--- a/resources/js/Pages/Chart/ChartTPO.tsx
+++ b/resources/js/Pages/Chart/ChartTPO.tsx
@@ -6,41 +6,81 @@ import "chart.js/auto";
 import AppBarTriple from "@/Components/Shared/AppBarTriple";
 import ShowAssignmentIcon from "@mui/icons-material/Assignment";
 import ButtonEndHref from "@/Components/Shared/ButtonEndHref";
-import {singleLineChart} from "@/helpers/generator/chart-generator";
+import {singleLineChart, singleLineChartString} from "@/helpers/generator/chart-generator";
 import AggregationSingle from "@/Components/Chart/AggregationSingle";
 import GoogleMap from "@/Components/Map/GoogleMap";
+import timeMinuteString from "@/helpers/converter/date-time";
+import calculateMetrics from "@/helpers/analysis/calculate-metric";
+import getCreatedAt from "@/helpers/analysis/get-createdat";
+import {AmbientTemperature, OilLevel, Pressure, Temperature} from "@/types/metric";
 
 export default function ChartTPO({
-                                       trafo,
-                                       date,
+                                     trafo,
+                                     date,
+                                     temperatures,
+                                     pressures,
+                                     oilLevels,
+                                     ambientTemperatures,
                                    }: ChartTPOProps) {
     const mapApiKey = import.meta.env.VITE_MAP_API_KEY;
     const theme = useTheme()
     const onlyMediumScreen = useMediaQuery(theme.breakpoints.down('md'));
 
-    const metricTemperature = singleLineChart({
-        labels: [],
-        data: [],
+    const metricTemperature = singleLineChartString({
+        labels: temperatures.map(temperature => timeMinuteString(new Date(temperature.created_at))),
+        data: temperatures.map(temperature => temperature.temperature),
         label: 'Temperature',
     });
 
-    const metricPressure = singleLineChart({
-        labels: [],
-        data: [],
+    const temperatureAggregation = calculateMetrics(temperatures.map(
+        temperature => temperature.temperature
+    ));
+    const temperatureCreatedAt = getCreatedAt<Temperature>(
+        temperatures, 'temperature', 'created_at'
+    );
+    const { temperature = 0 } = temperatures[temperatures.length - 1] || {};
+
+    const metricPressure = singleLineChartString({
+        labels: pressures.map(pressure => timeMinuteString(new Date(pressure.created_at))),
+        data: pressures.map(pressure => pressure.pressure),
         label: 'Pressure',
     });
 
-    const metricOilLevel = singleLineChart({
-        labels: [],
-        data: [],
+    const pressureAggregation = calculateMetrics(pressures.map(
+        pressure => pressure.pressure
+    ));
+    const pressureCreatedAt = getCreatedAt<Pressure>(
+        pressures, 'pressure', 'created_at'
+    );
+    const { pressure = 0 } = pressures[pressures.length - 1] || {};
+
+    const metricOilLevel = singleLineChartString({
+        labels: oilLevels.map(oilLevel => timeMinuteString(new Date(oilLevel.created_at))),
+        data: oilLevels.map(oilLevel => oilLevel.oil_level),
         label: 'Oil Level',
     });
 
-    const metricAmbientTemperature = singleLineChart({
-        labels: [],
-        data: [],
+    const oilLevelAggregation = calculateMetrics(oilLevels.map(
+        oilLevel => oilLevel.oil_level
+    ));
+    const oilLevelCreatedAt = getCreatedAt<OilLevel>(
+        oilLevels, 'oil_level', 'created_at'
+    );
+    const { oil_level = 0 } = oilLevels[oilLevels.length - 1] || {};
+
+    const metricAmbientTemperature = singleLineChartString({
+        labels: ambientTemperatures.map(ambientTemperature => timeMinuteString(new Date(ambientTemperature.created_at))),
+        data: ambientTemperatures.map(ambientTemperature => ambientTemperature.ambient_temperature),
         label: 'Ambient Temperature',
     });
+
+    const ambientTemperatureAggregation = calculateMetrics(ambientTemperatures.map(
+        ambientTemperature => ambientTemperature.ambient_temperature
+    ));
+    const ambientTemperatureCreatedAt = getCreatedAt<AmbientTemperature>(
+        ambientTemperatures, 'ambient_temperature', 'created_at'
+    );
+    const { ambient_temperature = 0 } = ambientTemperatures[ambientTemperatures.length - 1] || {};
 
     return (
         <>
@@ -73,12 +113,12 @@ export default function ChartTPO({
                             <Container sx={{ p: 2 }}>
                                 <AggregationSingle
                                     property={"Temperature"}
-                                    max={0}
-                                    avg={0}
-                                    min={0}
-                                    latest={0}
-                                    maxTime={''}
-                                    minTime={''}
+                                    max={temperatureAggregation.max}
+                                    avg={temperatureAggregation.avg}
+                                    min={temperatureAggregation.min}
+                                    latest={temperature}
+                                    maxTime={timeMinuteString(new Date(temperatureCreatedAt.max))}
+                                    minTime={timeMinuteString(new Date(temperatureCreatedAt.min))}
                                 />
                             </Container>
                         </Box>
@@ -94,12 +134,12 @@ export default function ChartTPO({
                             <Container sx={{ p: 2 }}>
                                 <AggregationSingle
                                     property={"Pressure"}
-                                    max={0}
-                                    avg={0}
-                                    min={0}
-                                    latest={0}
-                                    maxTime={''}
-                                    minTime={''}
+                                    max={pressureAggregation.max}
+                                    avg={pressureAggregation.avg}
+                                    min={pressureAggregation.min}
+                                    latest={pressure}
+                                    maxTime={timeMinuteString(new Date(pressureCreatedAt.max))}
+                                    minTime={timeMinuteString(new Date(pressureCreatedAt.min))}
                                 />
                             </Container>
                         </Box>
@@ -120,12 +160,12 @@ export default function ChartTPO({
                             <Container sx={{ p: 2 }}>
                                 <AggregationSingle
                                     property={"Oil Level"}
-                                    max={0}
-                                    avg={0}
-                                    min={0}
-                                    latest={0}
-                                    maxTime={''}
-                                    minTime={''}
+                                    max={oilLevelAggregation.max}
+                                    avg={oilLevelAggregation.avg}
+                                    min={oilLevelAggregation.min}
+                                    latest={oil_level}
+                                    maxTime={timeMinuteString(new Date(oilLevelCreatedAt.max))}
+                                    minTime={timeMinuteString(new Date(oilLevelCreatedAt.min))}
                                 />
                             </Container>
                         </Box>
@@ -141,12 +181,12 @@ export default function ChartTPO({
                             <Container sx={{ p: 2 }}>
                                 <AggregationSingle
                                     property={"Ambient Temp"}
-                                    max={0}
-                                    avg={0}
-                                    min={0}
-                                    latest={0}
-                                    maxTime={''}
-                                    minTime={''}
+                                    max={ambientTemperatureAggregation.max}
+                                    avg={ambientTemperatureAggregation.avg}
+                                    min={ambientTemperatureAggregation.min}
+                                    latest={ambient_temperature}
+                                    maxTime={timeMinuteString(new Date(ambientTemperatureCreatedAt.max))}
+                                    minTime={timeMinuteString(new Date(ambientTemperatureCreatedAt.min))}
                                 />
                             </Container>
                         </Box>

--- a/resources/js/Pages/Metric/MetricPKA.tsx
+++ b/resources/js/Pages/Metric/MetricPKA.tsx
@@ -71,13 +71,13 @@ export default function MetricPKA({trafo, date, powerLosses, kFactors, triplenCu
                     <Grid item xs={12} md={6}>
                         <GaugeGroup
                             gauges={[powerLoss]}
-                            labels={['PL']}
+                            labels={['Power Loss']}
                         />
                     </Grid>
                     <Grid item xs={12} md={6}>
                         <GaugeGroup
                             gauges={[kFactor]}
-                            labels={['KF']}
+                            labels={['K Factor']}
                         />
                     </Grid>
                     <Grid item xs={12} md={6}>
@@ -107,7 +107,7 @@ export default function MetricPKA({trafo, date, powerLosses, kFactors, triplenCu
                     <Grid item xs={12}>
                         <GaugeGroup
                             gauges={[triplenCurrent]}
-                            labels={['TC']}
+                            labels={['Triplen Current']}
                         />
                     </Grid>
                     <Grid item xs={12}>

--- a/resources/js/Pages/Metric/MetricTPO.tsx
+++ b/resources/js/Pages/Metric/MetricTPO.tsx
@@ -6,7 +6,14 @@ import { MetricTPOProps } from "@/types/metric";
 import { Container, Grid } from "@mui/material";
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 
-export default function MetricTPO({trafo, date}: MetricTPOProps) {
+export default function MetricTPO({
+    trafo,
+    date,
+    temperatures,
+    pressures,
+    oilLevels,
+    ambientTemperatures,
+                                  }: MetricTPOProps) {
     const columnsTemperature: GridColDef[] = [
         { field: 'id', headerName: 'ID'},
         { field: 'createdAt', headerName: 'Date', width: 200},
@@ -31,6 +38,43 @@ export default function MetricTPO({trafo, date}: MetricTPOProps) {
         { field: 'ambient_temperature', headerName: 'Ambient Temperature (°C)', width: 200},
     ]
 
+    const rowsTemperature = temperatures.map((temperature) => {
+        return {
+            id: temperature.id,
+            createdAt: new Date(temperature.created_at).toLocaleString(),
+            temperature: temperature.temperature,
+        }
+    });
+
+    const rowsPressure = pressures.map((pressure) => {
+        return {
+            id: pressure.id,
+            createdAt: new Date(pressure.created_at).toLocaleString(),
+            pressure: pressure.pressure,
+        }
+    });
+
+    const rowsOilLevel = oilLevels.map((oilLevel) => {
+        return {
+            id: oilLevel.id,
+            createdAt: new Date(oilLevel.created_at).toLocaleString(),
+            oil_level: oilLevel.oil_level,
+        }
+    });
+
+    const rowsAmbientTemperature = ambientTemperatures.map((ambientTemperature) => {
+        return {
+            id: ambientTemperature.id,
+            createdAt: new Date(ambientTemperature.created_at).toLocaleString(),
+            ambient_temperature: ambientTemperature.ambient_temperature,
+        }
+    });
+
+    const temperature = [...temperatures.map((temperature) => temperature.temperature)];
+    const pressure = [...pressures.map((pressure) => pressure.pressure)];
+    const oilLevel = [...oilLevels.map((oilLevel) => oilLevel.oil_level)];
+    const ambientTemperature = [...ambientTemperatures.map((ambientTemperature) => ambientTemperature.ambient_temperature)];
+
     return (
         <>
             <AppBarTriple
@@ -48,19 +92,19 @@ export default function MetricTPO({trafo, date}: MetricTPOProps) {
                 <Grid container spacing={2}>
                     <Grid item xs={12} md={6}>
                         <GaugeGroup
-                            gauges={[[0]]}
+                            gauges={[temperature]}
                             labels={['Oil Temp']}
                         />
                     </Grid>
                     <Grid item xs={12} md={6}>
                         <GaugeGroup
-                            gauges={[[0]]}
+                            gauges={[pressure]}
                             labels={['Pressure']}
                         />
                     </Grid>
                     <Grid item xs={12} md={6}>
                         <DataGrid
-                            rows={[]}
+                            rows={rowsTemperature}
                             columns={columnsTemperature}
                             initialState={{
                                 pagination: {
@@ -72,7 +116,7 @@ export default function MetricTPO({trafo, date}: MetricTPOProps) {
                     </Grid>
                     <Grid item xs={12} md={6}>
                         <DataGrid
-                            rows={[]}
+                            rows={rowsPressure}
                             columns={columnsPressure}
                             initialState={{
                                 pagination: {
@@ -84,19 +128,19 @@ export default function MetricTPO({trafo, date}: MetricTPOProps) {
                     </Grid>
                     <Grid item xs={12} md={6}>
                         <GaugeGroup
-                            gauges={[[0]]}
+                            gauges={[oilLevel]}
                             labels={['Oil Level']}
                         />
                     </Grid>
                     <Grid item xs={12} md={6}>
                         <GaugeGroup
-                            gauges={[[0]]}
+                            gauges={[ambientTemperature]}
                             labels={['Ambient Temp']}
                         />
                     </Grid>
                     <Grid item xs={12} md={6}>
                         <DataGrid
-                            rows={[]}
+                            rows={rowsOilLevel}
                             columns={columnsOilLevel}
                             initialState={{
                                 pagination: {
@@ -108,7 +152,7 @@ export default function MetricTPO({trafo, date}: MetricTPOProps) {
                     </Grid>
                     <Grid item xs={12} md={6}>
                         <DataGrid
-                            rows={[]}
+                            rows={rowsAmbientTemperature}
                             columns={columnsAmbientTemperature}
                             initialState={{
                                 pagination: {

--- a/resources/js/Pages/Metric/MetricVIF.tsx
+++ b/resources/js/Pages/Metric/MetricVIF.tsx
@@ -143,6 +143,9 @@ export default function Metric({ trafo, date, voltages, currents, frequencies }:
                         <GaugeGroup
                             gauges={[frequency]}
                             labels={['Frequency']}
+                            isOverride={true}
+                            upperSafeThreshold={50.5}
+                            lowerSafeThreshold={49.5}
                         />
                     </Grid>
                     <Grid item xs={12}>

--- a/resources/js/types/chart.d.ts
+++ b/resources/js/types/chart.d.ts
@@ -1,12 +1,13 @@
 import {PageProps, TrafoV1} from "@/types/index";
 import {
+    AmbientTemperature,
     Metric, MetricApparentPower,
     MetricCurrent,
     MetricFrequency,
     MetricHD, MetricKFactor, MetricPower, MetricPowerFactor, MetricPowerLoss, MetricReactivePower,
     MetricTHDCurrent,
     MetricTHDVoltage, MetricTriplenCurrent,
-    MetricVoltage
+    MetricVoltage, OilLevel, Pressure, Temperature
 } from "@/types/metric";
 
 export interface AveragedMetric {
@@ -173,6 +174,10 @@ export type ChartIHDProps = PageProps & {
 export type ChartTPOProps = PageProps & {
     trafo: TrafoV1;
     date: string;
+    temperatures: Temperature[],
+    pressures: Pressure[],
+    oilLevels: OilLevel[],
+    ambientTemperatures: AmbientTemperature[],
 }
 
 export type ChartPKAProps = PageProps & {

--- a/resources/js/types/component.d.ts
+++ b/resources/js/types/component.d.ts
@@ -24,7 +24,10 @@ export type OrderTableBodyProps = Props & {
 
 export type GaugeGroupProps = Props & {
     gauges: number[][]
-    labels: string[]
+    labels: string[],
+    isOverride?: boolean,
+    upperSafeThreshold?: number,
+    lowerSafeThreshold?: number,
 }
 
 export type AggregationRSTProps = Props & {

--- a/resources/js/types/metric.d.ts
+++ b/resources/js/types/metric.d.ts
@@ -122,6 +122,22 @@ export interface MetricHD extends Metric {
     h21: Order;
 }
 
+export interface Temperature extends Metric {
+    temperature: number;
+}
+
+export interface Pressure extends Metric {
+    pressure: number;
+}
+
+export interface OilLevel extends Metric {
+    oil_level: number;
+}
+
+export interface AmbientTemperature extends Metric {
+    ambient_temperature: number;
+}
+
 export type MetricVIFProps = PageProps & {
     trafo: TrafoV1;
     date: string;
@@ -156,6 +172,10 @@ export type MetricIHDProps = PageProps & {
 export type MetricTPOProps = PageProps & {
     trafo: TrafoV1;
     date: string;
+    temperatures: Temperature[];
+    pressures: Pressure[];
+    oilLevels: OilLevel[];
+    ambientTemperatures: AmbientTemperature[];
 }
 
 export type MetricPKAProps = PageProps & {

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,19 +82,19 @@ Route::prefix('metric')->middleware(['auth'])->group(function () {
 Route::prefix('chart')->middleware(['auth'])->group(function () {
    Route::get('/{trafoid}/{date}', [ChartController::class, 'getChartData'])
        ->name('chart.data');
-    Route::get('/vif/{trafoid}/{date}', [ChartController::class, 'getChartVIF'])
+    Route::get('/{trafoid}/{date}/vif', [ChartController::class, 'getChartVIF'])
         ->name('chart.vif');
-    Route::get('/pqspf/{trafoid}/{date}', [ChartController::class, 'getChartPQSPF'])
+    Route::get('/{trafoid}/{date}/pqspf', [ChartController::class, 'getChartPQSPF'])
         ->name('chart.pqspf');
-    Route::get('/thd-ihd/{trafoid}/{date}', [ChartController::class, 'getChartTHDIHD'])
+    Route::get('/{trafoid}/{date}/thd-ihd', [ChartController::class, 'getChartTHDIHD'])
         ->name('chart.thd-ihd');
-    Route::get('/ihd/{trafoid}/{date}', [ChartController::class, 'getChartIHD'])
+    Route::get('/{trafoid}/{date}/ihd', [ChartController::class, 'getChartIHD'])
         ->name('chart.ihd');
-    Route::get('/tpo/{trafoid}/{date}', [ChartController::class, 'getChartTPO'])
+    Route::get('/{trafoid}/{date}/tpo', [ChartController::class, 'getChartTPO'])
         ->name('chart.tpo');
-    Route::get('/pka/{trafoid}/{date}', [ChartController::class, 'getChartPKA'])
+    Route::get('/{trafoid}/{date}/pka', [ChartController::class, 'getChartPKA'])
         ->name('chart.pka');
-    Route::get('/analisis/{trafoid}/{date}', [ChartController::class, 'getChartAnalysis'])
+    Route::get('/{trafoid}/{date}/analisis', [ChartController::class, 'getChartAnalysis'])
         ->name('chart.analisis');
 });
 


### PR DESCRIPTION
## Changelog
- [added connection between db and metric tpo view](https://github.com/irvanrizkin/trafo-monitor/commit/7e1885d96b95ad6d02402d49406e70717f4340e2)
- [added connection between db and chart tpo view](https://github.com/irvanrizkin/trafo-monitor/commit/ddae7c19e609ea9fb0e4c4864bd16bc2ad55d8d2)
- [adjust gauge text at metric PKA](https://github.com/irvanrizkin/trafo-monitor/commit/bd1dd8cb114832e07006cb6ec802c86033af606a)
- [change route back to before railway](https://github.com/irvanrizkin/trafo-monitor/commit/8daff29ece2f809cd7d8efe7b2692f20f4d122b3)
- [modify gauge condition for frequency at metric vif](https://github.com/irvanrizkin/trafo-monitor/commit/ebc5ede19e66e111ad4acfd6bfed7b60f210d58c)

## Issue Link
- [TM-27](https://irvanrizkin.atlassian.net/browse/TM-27)
