### PR TITLE
Added Datetime Unique and IHD V2

### DIFF
--- a/app/Http/Controllers/ChartController.php
+++ b/app/Http/Controllers/ChartController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Models\IHD;
+use App\Models\IHDCurrentV2;
 use App\Models\IHDVoltage;
+use App\Models\IHDVoltageV2;
 use App\Models\Metric;
 use App\Models\Trafo;
 use Illuminate\Http\Request;
@@ -63,6 +65,22 @@ class ChartController extends Controller
             'title' => 'Chart IHD',
             'ihdCurrents' => $ihd,
             'ihdVoltages' => $ihdVoltages,
+        ]);
+    }
+
+    public function getChartIHDV2($trafoId) {
+        $trafo = Trafo::find($trafoId);
+        if (!$trafo) {
+            return redirect()->route('not-found');
+        }
+        $ihdVoltages = IHDVoltageV2::where('trafo_id', $trafoId)->latest()->get();
+        $ihdCurrents = IHDCurrentV2::where('trafo_id', $trafoId)->latest()->get();
+
+        return Inertia::render('Chart/ChartIHDV2', [
+            'trafo' => $trafo,
+            'title' => 'Chart IHD',
+            'ihdVoltages' => $ihdVoltages,
+            'ihdCurrents' => $ihdCurrents,
         ]);
     }
 

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -9,6 +9,7 @@ use App\Models\Current;
 use App\Models\DateGroup;
 use App\Models\Frequency;
 use App\Models\OilLevel;
+use App\Models\Power;
 use App\Models\PowerFactor;
 use App\Models\Pressure;
 use App\Models\Temperature;
@@ -167,30 +168,34 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['apparent_power_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($apparentPower, 201);
+            // Active Power
+            case 'data14':
+                $power = Power::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'power_r' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['power_r']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($power, 201);
             case 'data15':
-                $pressure = Pressure::create([
+                $power = Power::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'pressure' => $value,
-                ]);
+                    'power_s' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['power_s']);
                 $this->insertTodayDate($trafoId);
-                return response()->json($pressure, 201);
+                return response()->json($power, 201);
             case 'data16':
-                $temperature = Temperature::create([
+                $power = Power::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'temperature' => $value,
-                ]);
+                    'power_t' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['power_t']);
                 $this->insertTodayDate($trafoId);
-                return response()->json($temperature, 201);
-            case 'data17':
-                $ambientTemp = AmbientTemperature::create([
-                    'trafo_id' => $trafoId,
-                    'topic_name' => $topic,
-                    'ambient_temperature' => $value,
-                ]);
-                $this->insertTodayDate($trafoId);
-                return response()->json($ambientTemp, 201);
+                return response()->json($power, 201);
             case 'data18':
                 $oilLevel = OilLevel::create([
                     'trafo_id' => $trafoId,

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -252,6 +252,34 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($thdVoltage, 201);
+            // THD Current
+            case 'data54':
+                $thdCurrent = THDCurrent::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($thdCurrent, 201);
+            case 'data55':
+                $thdCurrent = THDCurrent::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($thdCurrent, 201);
+            case 'data56':
+                $thdCurrent = THDCurrent::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($thdCurrent, 201);
             default:
                 return response()->json([
                     'message' => 'Invalid topic',

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -309,6 +309,15 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['k_factor_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($kFactor, 201);
+            case 'data91':
+                $pressure = Pressure::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'pressure' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['pressure']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($pressure, 201);
             case 'data92':
                 $temperature = Temperature::upsert([
                     'trafo_id' => $trafoId,

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -34,36 +34,30 @@ class MetricMQTTController extends Controller
         }
         switch ($topic) {
             case 'data1':
-                $lastVoltage = Voltage::where('trafo_id', $trafoId)->latest()->first();
-                $voltage = Voltage::create([
+                $voltage = Voltage::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
                     'voltage_r' => $value,
-                    'voltage_s' => $lastVoltage?->voltage_s ?? 0,
-                    'voltage_t' => $lastVoltage?->voltage_t ?? 0,
-                ]);
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($voltage, 201);
             case 'data2':
-                $lastVoltage = Voltage::where('trafo_id', $trafoId)->latest()->first();
-                $voltage = Voltage::create([
+                $voltage = Voltage::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'voltage_r' => $lastVoltage?->voltage_r ?? 0,
                     'voltage_s' => $value,
-                    'voltage_t' => $lastVoltage?->voltage_t ?? 0,
-                ]);
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($voltage, 201);
             case 'data3':
-                $lastVoltage = Voltage::where('trafo_id', $trafoId)->latest()->first();
-                $voltage = Voltage::create([
+                $voltage = Voltage::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'voltage_r' => $lastVoltage?->voltage_r ?? 0,
-                    'voltage_s' => $lastVoltage?->voltage_s ?? 0,
                     'voltage_t' => $value,
-                ]);
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($voltage, 201);
             case 'data4':

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -224,6 +224,34 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['frequency_r']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($frequency, 201);
+            // THD Voltage
+            case 'data21':
+                $thdVoltage = THDVoltage::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($thdVoltage, 201);
+            case 'data22':
+                $thdVoltage = THDVoltage::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($thdVoltage, 201);
+            case 'data23':
+                $thdVoltage = THDVoltage::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($thdVoltage, 201);
             default:
                 return response()->json([
                     'message' => 'Invalid topic',

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -71,51 +71,39 @@ class MetricMQTTController extends Controller
                 $this->insertTodayDate($trafoId);
                 return response()->json($frequency, 201);
             case 'data5':
-                $lastCurrent = Current::where('trafo_id', $trafoId)->latest()->first();
-                $current = Current::create([
+                $current = Current::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
                     'current_r' => $value,
-                    'current_s' => $lastCurrent?->current_s ?? 0,
-                    'current_t' => $lastCurrent?->current_t ?? 0,
-                    'current_in' => $lastCurrent?->current_in ?? 0,
-                ]);
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($current, 201);
             case 'data6':
-                $lastCurrent = Current::where('trafo_id', $trafoId)->latest()->first();
-                $current = Current::create([
+                $current = Current::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'current_r' => $lastCurrent?->current_r ?? 0,
                     'current_s' => $value,
-                    'current_t' => $lastCurrent?->current_t ?? 0,
-                    'current_in' => $lastCurrent?->current_in ?? 0,
-                ]);
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($current, 201);
             case 'data7':
-                $lastCurrent = Current::where('trafo_id', $trafoId)->latest()->first();
-                $current = Current::create([
+                $current = Current::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'current_r' => $lastCurrent?->current_r ?? 0,
-                    'current_s' => $lastCurrent?->current_s ?? 0,
                     'current_t' => $value,
-                    'current_in' => $lastCurrent?->current_in ?? 0,
-                ]);
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($current, 201);
             case 'data8':
-                $lastCurrent = Current::where('trafo_id', $trafoId)->latest()->first();
-                $current = Current::create([
+                $current = Current::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'current_r' => $lastCurrent?->current_r ?? 0,
-                    'current_s' => $lastCurrent?->current_s ?? 0,
-                    'current_t' => $lastCurrent?->current_t ?? 0,
                     'current_in' => $value,
-                ]);
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_in']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($current, 201);
             case 'data9':

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -336,6 +336,15 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['ambient_temperature']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($ambientTemperature, 201);
+            case 'data94':
+                $oilLevel = OilLevel::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'oil_level' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['oil_level']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($oilLevel, 201);
             default:
                 return response()->json([
                     'message' => 'Invalid topic',

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -8,6 +8,7 @@ use App\Models\Current;
 use App\Models\DateGroup;
 use App\Models\Frequency;
 use App\Models\OilLevel;
+use App\Models\PowerFactor;
 use App\Models\Pressure;
 use App\Models\Temperature;
 use App\Models\THDCurrent;
@@ -33,6 +34,7 @@ class MetricMQTTController extends Controller
             ], 400);
         }
         switch ($topic) {
+            // Voltage
             case 'data1':
                 $voltage = Voltage::upsert([
                     'trafo_id' => $trafoId,
@@ -60,7 +62,8 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($voltage, 201);
-            case 'data4':
+            // Frequency
+            case 'data20':
                 $frequency = Frequency::create([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
@@ -70,7 +73,8 @@ class MetricMQTTController extends Controller
                 ]);
                 $this->insertTodayDate($trafoId);
                 return response()->json($frequency, 201);
-            case 'data5':
+            // Current
+            case 'data4':
                 $current = Current::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
@@ -79,7 +83,7 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['current_r']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($current, 201);
-            case 'data6':
+            case 'data5':
                 $current = Current::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
@@ -88,7 +92,7 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['current_s']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($current, 201);
-            case 'data7':
+            case 'data6':
                 $current = Current::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
@@ -97,7 +101,7 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['current_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($current, 201);
-            case 'data8':
+            case 'data7':
                 $current = Current::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
@@ -106,39 +110,33 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['current_in']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($current, 201);
+            case 'data8':
+                $powerFactor = PowerFactor::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'power_factor_r' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['power_factor_r']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($powerFactor, 201);
             case 'data9':
-                $lastTHDVoltage = THDVoltage::where('trafo_id', $trafoId)->latest()->first();
-                $thdVoltage = THDVoltage::create([
+                $powerFactor = PowerFactor::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'voltage_r' => $value,
-                    'voltage_s' => $lastTHDVoltage?->voltage_s ?? 0,
-                    'voltage_t' => $lastTHDVoltage?->voltage_t ?? 0,
-                ]);
+                    'power_factor_s' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['power_factor_s']);
                 $this->insertTodayDate($trafoId);
-                return response()->json($thdVoltage, 201);
+                return response()->json($powerFactor, 201);
             case 'data10':
-                $lastTHDVoltage = THDVoltage::where('trafo_id', $trafoId)->latest()->first();
-                $thdVoltage = THDVoltage::create([
+                $powerFactor = PowerFactor::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'voltage_r' => $lastTHDVoltage?->voltage_r ?? 0,
-                    'voltage_s' => $value,
-                    'voltage_t' => $lastTHDVoltage?->voltage_t ?? 0,
-                ]);
+                    'power_factor_t' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['power_factor_t']);
                 $this->insertTodayDate($trafoId);
-                return response()->json($thdVoltage, 201);
-            case 'data11':
-                $lastTHDVoltage = THDVoltage::where('trafo_id', $trafoId)->latest()->first();
-                $thdVoltage = THDVoltage::create([
-                    'trafo_id' => $trafoId,
-                    'topic_name' => $topic,
-                    'voltage_r' => $lastTHDVoltage?->voltage_r ?? 0,
-                    'voltage_s' => $lastTHDVoltage?->voltage_s ?? 0,
-                    'voltage_t' => $value,
-                ]);
-                $this->insertTodayDate($trafoId);
-                return response()->json($thdVoltage, 201);
+                return response()->json($powerFactor, 201);
             case 'data12':
                 $lastTHDCurrent = THDCurrent::where('trafo_id', $trafoId)->latest()->first();
                 $thdCurrent = THDCurrent::create([

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Metric;
 
 use App\Http\Controllers\Controller;
 use App\Models\AmbientTemperature;
+use App\Models\ApparentPower;
 use App\Models\Current;
 use App\Models\DateGroup;
 use App\Models\Frequency;
@@ -110,6 +111,7 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['current_in']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($current, 201);
+            // Power Factor
             case 'data8':
                 $powerFactor = PowerFactor::upsert([
                     'trafo_id' => $trafoId,
@@ -137,39 +139,34 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['power_factor_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($powerFactor, 201);
+            // Apparent Power
+            case 'data11':
+                $apparentPower = ApparentPower::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'apparent_power_r' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['apparent_power_r']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($apparentPower, 201);
             case 'data12':
-                $lastTHDCurrent = THDCurrent::where('trafo_id', $trafoId)->latest()->first();
-                $thdCurrent = THDCurrent::create([
+                $apparentPower = ApparentPower::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'current_r' => $value,
-                    'current_s' => $lastTHDCurrent?->current_s ?? 0,
-                    'current_t' => $lastTHDCurrent?->current_t ?? 0,
-                ]);
+                    'apparent_power_s' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['apparent_power_s']);
                 $this->insertTodayDate($trafoId);
-                return response()->json($thdCurrent, 201);
+                return response()->json($apparentPower, 201);
             case 'data13':
-                $lastTHDCurrent = THDCurrent::where('trafo_id', $trafoId)->latest()->first();
-                $thdCurrent = THDCurrent::create([
+                $apparentPower = ApparentPower::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'current_r' => $lastTHDCurrent?->current_r ?? 0,
-                    'current_s' => $value,
-                    'current_t' => $lastTHDCurrent?->current_t ?? 0,
-                ]);
+                    'apparent_power_t' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['apparent_power_t']);
                 $this->insertTodayDate($trafoId);
-                return response()->json($thdCurrent, 201);
-            case 'data14':
-                $lastTHDCurrent = THDCurrent::where('trafo_id', $trafoId)->latest()->first();
-                $thdCurrent = THDCurrent::create([
-                    'trafo_id' => $trafoId,
-                    'topic_name' => $topic,
-                    'current_r' => $lastTHDCurrent?->current_r ?? 0,
-                    'current_s' => $lastTHDCurrent?->current_s ?? 0,
-                    'current_t' => $value,
-                ]);
-                $this->insertTodayDate($trafoId);
-                return response()->json($thdCurrent, 201);
+                return response()->json($apparentPower, 201);
             case 'data15':
                 $pressure = Pressure::create([
                     'trafo_id' => $trafoId,

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -327,6 +327,15 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['temperature']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($temperature, 201);
+            case 'data93':
+                $ambientTemperature = AmbientTemperature::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'ambient_temperature' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['ambient_temperature']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ambientTemperature, 201);
             default:
                 return response()->json([
                     'message' => 'Invalid topic',

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -373,6 +373,97 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h19']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($ihdCurrent, 201);
+            // IHD Current S
+            case 'data68':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h1' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h1']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data69':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h3' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h3']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data70':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h5' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h5']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data71':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h7' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h7']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data72':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h9' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h9']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data73':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h11' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h11']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data74':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h13' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h13']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data75':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h15' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h15']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data76':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h17' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h17']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data77':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_s_h19' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h19']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
             // K Factor
             case 'data88':
                 $kFactor = KFactor::upsert([

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -9,6 +9,7 @@ use App\Models\Current;
 use App\Models\DateGroup;
 use App\Models\Frequency;
 use App\Models\IHDCurrentV2;
+use App\Models\IHDVoltageV2;
 use App\Models\KFactor;
 use App\Models\OilLevel;
 use App\Models\Power;
@@ -254,6 +255,279 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($thdVoltage, 201);
+            // IHD Voltage R
+            case 'data24':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h1' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h1']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data25':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h3' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h3']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data26':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h5' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h5']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data27':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h7' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h7']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data28':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h9' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h9']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data29':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h11' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h11']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data30':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h13' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h13']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data31':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h15' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h15']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data32':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h17' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h17']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data33':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_r_h19' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_r_h19']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            // IHD Voltage S
+            case 'data34':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h1' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h1']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data35':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h3' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h3']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data36':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h5' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h5']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data37':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h7' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h7']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data38':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h9' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h9']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data39':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h11' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h11']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data40':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h13' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h13']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data41':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h15' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h15']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data42':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h17' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h17']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data43':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_s_h19' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_s_h19']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            // IHD Voltage T
+            case 'data44':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h1' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h1']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data45':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h3' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h3']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data46':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h5' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h5']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data47':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h7' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h7']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data48':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h9' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h9']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data49':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h11' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h11']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data50':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h13' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h13']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data51':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h15' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h15']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data52':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h17' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h17']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
+            case 'data53':
+                $ihdVoltage = IHDVoltageV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'voltage_t_h19' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t_h19']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdVoltage, 201);
             // THD Current
             case 'data54':
                 $thdCurrent = THDCurrent::upsert([

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -8,6 +8,7 @@ use App\Models\ApparentPower;
 use App\Models\Current;
 use App\Models\DateGroup;
 use App\Models\Frequency;
+use App\Models\KFactor;
 use App\Models\OilLevel;
 use App\Models\Power;
 use App\Models\PowerFactor;
@@ -280,6 +281,34 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['current_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($thdCurrent, 201);
+            // K Factor
+            case 'data88':
+                $kFactor = KFactor::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'k_factor_r' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['k_factor_r']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($kFactor, 201);
+            case 'data89':
+                $kFactor = KFactor::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'k_factor_s' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['k_factor_s']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($kFactor, 201);
+            case 'data90':
+                $kFactor = KFactor::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'k_factor_t' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['k_factor_t']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($kFactor, 201);        
             default:
                 return response()->json([
                     'message' => 'Invalid topic',

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -308,7 +308,16 @@ class MetricMQTTController extends Controller
                     'datetime' => Carbon::now()->toDateTimeString(),
                 ], ['trafo_id', 'topic_name', 'datetime'], ['k_factor_t']);
                 $this->insertTodayDate($trafoId);
-                return response()->json($kFactor, 201);        
+                return response()->json($kFactor, 201);
+            case 'data92':
+                $temperature = Temperature::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'temperature' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['temperature']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($temperature, 201);
             default:
                 return response()->json([
                     'message' => 'Invalid topic',

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -8,6 +8,7 @@ use App\Models\ApparentPower;
 use App\Models\Current;
 use App\Models\DateGroup;
 use App\Models\Frequency;
+use App\Models\IHDCurrentV2;
 use App\Models\KFactor;
 use App\Models\OilLevel;
 use App\Models\Power;
@@ -281,6 +282,97 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['current_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($thdCurrent, 201);
+            // IHD Current R
+            case 'data57':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h1' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h1']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data58':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h3' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h3']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data59':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h5' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h5']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data60':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h7' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h7']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data61':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h9' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h9']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data62':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h11' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h11']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data63':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h13' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h13']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data64':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h15' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h15']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data65':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h17' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h17']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data67':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_r_h19' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_r_h19']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
             // K Factor
             case 'data88':
                 $kFactor = KFactor::upsert([

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -65,17 +65,6 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['voltage_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($voltage, 201);
-            // Frequency
-            case 'data20':
-                $frequency = Frequency::create([
-                    'trafo_id' => $trafoId,
-                    'topic_name' => $topic,
-                    'frequency_r' => $value,
-                    'frequency_s' => $value,
-                    'frequency_t' => $value,
-                ]);
-                $this->insertTodayDate($trafoId);
-                return response()->json($frequency, 201);
             // Current
             case 'data4':
                 $current = Current::upsert([
@@ -197,6 +186,7 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['power_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($power, 201);
+            // Reactive Power
             case 'data17':
                 $reactivePower = ReactivePower::upsert([
                     'trafo_id' => $trafoId,
@@ -224,6 +214,16 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['reactive_power_s']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($reactivePower, 201);
+            // Frequency
+            case 'data20':
+                $frequency = Frequency::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'frequency_r' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['frequency_r']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($frequency, 201);
             default:
                 return response()->json([
                     'message' => 'Invalid topic',

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -464,6 +464,97 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['current_s_h19']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($ihdCurrent, 201);
+            // IHD Current T
+            case 'data78':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h1' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h1']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data79':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h3' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h3']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data80':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h5' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h5']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data81':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h7' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h7']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data82':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h9' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h9']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data83':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h11' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h11']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data84':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h13' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h13']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data85':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h15' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h15']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data86':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h17' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h17']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
+            case 'data87':
+                $ihdCurrent = IHDCurrentV2::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'current_t_h19' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['current_t_h19']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($ihdCurrent, 201);
             // K Factor
             case 'data88':
                 $kFactor = KFactor::upsert([

--- a/app/Http/Controllers/Metric/MetricMQTTController.php
+++ b/app/Http/Controllers/Metric/MetricMQTTController.php
@@ -12,6 +12,7 @@ use App\Models\OilLevel;
 use App\Models\Power;
 use App\Models\PowerFactor;
 use App\Models\Pressure;
+use App\Models\ReactivePower;
 use App\Models\Temperature;
 use App\Models\THDCurrent;
 use App\Models\THDVoltage;
@@ -196,14 +197,33 @@ class MetricMQTTController extends Controller
                 ], ['trafo_id', 'topic_name', 'datetime'], ['power_t']);
                 $this->insertTodayDate($trafoId);
                 return response()->json($power, 201);
-            case 'data18':
-                $oilLevel = OilLevel::create([
+            case 'data17':
+                $reactivePower = ReactivePower::upsert([
                     'trafo_id' => $trafoId,
                     'topic_name' => $topic,
-                    'ambient_temperature' => $value,
-                ]);
+                    'reactive_power_r' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['reactive_power_r']);
                 $this->insertTodayDate($trafoId);
-                return response()->json($oilLevel, 201);
+                return response()->json($reactivePower, 201);
+            case 'data18':
+                $reactivePower = ReactivePower::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'reactive_power_s' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['reactive_power_s']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($reactivePower, 201);
+            case 'data19':
+                $reactivePower = ReactivePower::upsert([
+                    'trafo_id' => $trafoId,
+                    'topic_name' => $topic,
+                    'reactive_power_s' => $value,
+                    'datetime' => Carbon::now()->toDateTimeString(),
+                ], ['trafo_id', 'topic_name', 'datetime'], ['reactive_power_s']);
+                $this->insertTodayDate($trafoId);
+                return response()->json($reactivePower, 201);
             default:
                 return response()->json([
                     'message' => 'Invalid topic',

--- a/app/Http/Controllers/MetricController.php
+++ b/app/Http/Controllers/MetricController.php
@@ -8,7 +8,9 @@ use App\Models\Current;
 use App\Models\Frequency;
 use App\Models\IHD;
 use App\Models\IHDCurrent;
+use App\Models\IHDCurrentV2;
 use App\Models\IHDVoltage;
+use App\Models\IHDVoltageV2;
 use App\Models\IndividualHarmonicDistortion;
 use App\Models\KFactor;
 use App\Models\Metric;
@@ -119,6 +121,24 @@ class MetricController extends Controller
             'chartRoute' => 'chart.ihd',
             'ihdCurrents' => $ihd,
             'ihdVoltages' => $ihdVoltage,
+        ]);
+    }
+
+    public function getMetricIHDV2($trafoId, $date) {
+        $trafo = Trafo::find($trafoId);
+        if (!$trafo) {
+            return redirect()->route('not-found');
+        }
+        $ihdCurrents = IHDCurrentV2::where('trafo_id', $trafoId)->get();
+        $ihdVoltages = IHDVoltageV2::where('trafo_id', $trafoId)->get();
+
+        return Inertia::render('Metric/MetricIHDV2', [
+            'trafo' => $trafo,
+            'date' => $date,
+            'title' => 'Metric IHD',
+            'chartRoute' => 'chart.ihd-v2',
+            'ihdCurrents' => $ihdCurrents,
+            'ihdVoltages' => $ihdVoltages,
         ]);
     }
 

--- a/app/Models/AmbientTemperature.php
+++ b/app/Models/AmbientTemperature.php
@@ -13,5 +13,6 @@ class AmbientTemperature extends Model
         'trafo_id',
         'topic_name',
         'ambient_temperature',
+        'datetime'
     ];
 }

--- a/app/Models/ApparentPower.php
+++ b/app/Models/ApparentPower.php
@@ -8,4 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class ApparentPower extends Model
 {
     use HasFactory;
+
+    protected $fillable = [
+        'trafo_id',
+        'topic_name',
+        'apparent_power_r',
+        'apparent_power_s',
+        'apparent_power_t',
+        'datetime',
+    ];
 }

--- a/app/Models/Current.php
+++ b/app/Models/Current.php
@@ -16,5 +16,6 @@ class Current extends Model
         'current_s',
         'current_t',
         'current_in',
+        'datetime',
     ];
 }

--- a/app/Models/Frequency.php
+++ b/app/Models/Frequency.php
@@ -15,5 +15,6 @@ class Frequency extends Model
         'frequency_r',
         'frequency_s',
         'frequency_t',
+        'datetime'
     ];
 }

--- a/app/Models/IHDCurrentV2.php
+++ b/app/Models/IHDCurrentV2.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class IHDCurrentV2 extends Model
+{
+    use HasFactory;
+
+    protected $table = 'ihd_currents';
+
+    protected $fillable = [
+        'trafo_id',
+        'topic_name',
+        'current_r_h1',
+        'current_s_h1',
+        'current_t_h1',
+        'current_r_h3',
+        'current_s_h3',
+        'current_t_h3',
+        'current_r_h5',
+        'current_s_h5',
+        'current_t_h5',
+        'current_r_h7',
+        'current_s_h7',
+        'current_t_h7',
+        'current_r_h9',
+        'current_s_h9',
+        'current_t_h9',
+        'current_r_h11',
+        'current_s_h11',
+        'current_t_h11',
+        'current_r_h13',
+        'current_s_h13',
+        'current_t_h13',
+        'current_r_h15',
+        'current_s_h15',
+        'current_t_h15',
+        'current_r_h17',
+        'current_s_h17',
+        'current_t_h17',
+        'current_r_h19',
+        'current_s_h19',
+        'current_t_h19',
+        'datetime'
+    ];
+}

--- a/app/Models/IHDVoltageV2.php
+++ b/app/Models/IHDVoltageV2.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class IHDVoltageV2 extends Model
+{
+    use HasFactory;
+
+    protected $table = 'ihd_voltages';
+
+    protected $fillable = [
+        'trafo_id',
+        'topic_name',
+        'voltage_r_h1',
+        'voltage_s_h1',
+        'voltage_t_h1',
+        'voltage_r_h3',
+        'voltage_s_h3',
+        'voltage_t_h3',
+        'voltage_r_h5',
+        'voltage_s_h5',
+        'voltage_t_h5',
+        'voltage_r_h7',
+        'voltage_s_h7',
+        'voltage_t_h7',
+        'voltage_r_h9',
+        'voltage_s_h9',
+        'voltage_t_h9',
+        'voltage_r_h11',
+        'voltage_s_h11',
+        'voltage_t_h11',
+        'voltage_r_h13',
+        'voltage_s_h13',
+        'voltage_t_h13',
+        'voltage_r_h15',
+        'voltage_s_h15',
+        'voltage_t_h15',
+        'voltage_r_h17',
+        'voltage_s_h17',
+        'voltage_t_h17',
+        'voltage_r_h19',
+        'voltage_s_h19',
+        'voltage_t_h19',
+        'datetime'
+    ];
+}

--- a/app/Models/KFactor.php
+++ b/app/Models/KFactor.php
@@ -8,4 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class KFactor extends Model
 {
     use HasFactory;
+
+    protected $fillable = [
+        'trafo_id',
+        'topic_name',
+        'k_factor_r',
+        'k_factor_s',
+        'k_factor_t',
+        'datetime'
+    ];
 }

--- a/app/Models/OilLevel.php
+++ b/app/Models/OilLevel.php
@@ -13,5 +13,6 @@ class OilLevel extends Model
         'trafo_id',
         'topic_name',
         'oil_level',
+        'datetime'
     ];
 }

--- a/app/Models/Power.php
+++ b/app/Models/Power.php
@@ -8,4 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class Power extends Model
 {
     use HasFactory;
+
+    protected $fillable = [
+        'trafo_id',
+        'topic_name',
+        'power_r',
+        'power_s',
+        'power_t',
+        'datetime',
+    ];
 }

--- a/app/Models/PowerFactor.php
+++ b/app/Models/PowerFactor.php
@@ -8,4 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class PowerFactor extends Model
 {
     use HasFactory;
+
+    protected $fillable = [
+        'trafo_id',
+        'topic_name',
+        'power_factor_r',
+        'power_factor_s',
+        'power_factor_t',
+        'datetime',
+    ];
 }

--- a/app/Models/Pressure.php
+++ b/app/Models/Pressure.php
@@ -13,5 +13,6 @@ class Pressure extends Model
         'trafo_id',
         'topic_name',
         'pressure',
+        'datetime'
     ];
 }

--- a/app/Models/ReactivePower.php
+++ b/app/Models/ReactivePower.php
@@ -8,4 +8,12 @@ use Illuminate\Database\Eloquent\Model;
 class ReactivePower extends Model
 {
     use HasFactory;
+
+    protected $fillable = [
+        'trafo_id',
+        'topic_name',
+        'reactive_power_r',
+        'reactive_power_s',
+        'reactive_power_t',
+    ];
 }

--- a/app/Models/THDCurrent.php
+++ b/app/Models/THDCurrent.php
@@ -15,5 +15,6 @@ class THDCurrent extends Model
         'current_r',
         'current_s',
         'current_t',
+        'datetime'
     ];
 }

--- a/app/Models/THDVoltage.php
+++ b/app/Models/THDVoltage.php
@@ -15,5 +15,6 @@ class THDVoltage extends Model
         'voltage_r',
         'voltage_s',
         'voltage_t',
+        'datetime'
     ];
 }

--- a/app/Models/Temperature.php
+++ b/app/Models/Temperature.php
@@ -13,5 +13,6 @@ class Temperature extends Model
         'trafo_id',
         'topic_name',
         'temperature',
+        'datetime',
     ];
 }

--- a/app/Models/Voltage.php
+++ b/app/Models/Voltage.php
@@ -15,5 +15,6 @@ class Voltage extends Model
         'voltage_r',
         'voltage_s',
         'voltage_t',
+        'datetime',
     ];
 }

--- a/database/migrations/2024_12_13_094625_add_datetime_to_voltages_table.php
+++ b/database/migrations/2024_12_13_094625_add_datetime_to_voltages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('voltages', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('voltage_r')->default(0)->change();
+            $table->double('voltage_s')->default(0)->change();
+            $table->double('voltage_t')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('voltages', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_13_141611_add_unique_datetime_at_currents_table.php
+++ b/database/migrations/2024_12_13_141611_add_unique_datetime_at_currents_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('currents', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('current_r')->default(0)->change();
+            $table->double('current_s')->default(0)->change();
+            $table->double('current_t')->default(0)->change();
+            $table->double('current_in')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('currents', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_13_161247_add_unique_datetime_at_power_factors_table.php
+++ b/database/migrations/2024_12_13_161247_add_unique_datetime_at_power_factors_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('power_factors', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('power_factor_r')->default(0)->change();
+            $table->double('power_factor_s')->default(0)->change();
+            $table->double('power_factor_t')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('power_factors', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_074316_add_unique_datetime_at_apparent_powers_table.php
+++ b/database/migrations/2024_12_14_074316_add_unique_datetime_at_apparent_powers_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('apparent_powers', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('apparent_power_r')->default(0)->change();
+            $table->double('apparent_power_s')->default(0)->change();
+            $table->double('apparent_power_t')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('apparent_powers', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_085702_add_unique_datetime_at_powers_table.php
+++ b/database/migrations/2024_12_14_085702_add_unique_datetime_at_powers_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('powers', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('power_r')->default(0)->change();
+            $table->double('power_s')->default(0)->change();
+            $table->double('power_t')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('powers', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_100653_add_unique_datetime_at_reactive_powers_table.php
+++ b/database/migrations/2024_12_14_100653_add_unique_datetime_at_reactive_powers_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('reactive_powers', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('reactive_power_r')->default(0)->change();
+            $table->double('reactive_power_s')->default(0)->change();
+            $table->double('reactive_power_t')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('reactive_powers', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_104650_add_unique_datetime_at_frequencies_table.php
+++ b/database/migrations/2024_12_14_104650_add_unique_datetime_at_frequencies_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('frequencies', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('frequency_r')->default(0)->change();
+            $table->double('frequency_s')->default(0)->change();
+            $table->double('frequency_t')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('frequecies', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_110246_add_unique_datetime_at_t_h_d_voltages_table.php
+++ b/database/migrations/2024_12_14_110246_add_unique_datetime_at_t_h_d_voltages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('t_h_d_voltages', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('voltage_r')->default(0)->change();
+            $table->double('voltage_s')->default(0)->change();
+            $table->double('voltage_t')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('t_h_d_voltages', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_112723_add_unique_datetime_at_t_h_d_currents_table.php
+++ b/database/migrations/2024_12_14_112723_add_unique_datetime_at_t_h_d_currents_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('t_h_d_currents', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('current_r')->default(0)->change();
+            $table->double('current_s')->default(0)->change();
+            $table->double('current_t')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('t_h_d_currents', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_131201_add_unique_datetime_at_k_factors_table.php
+++ b/database/migrations/2024_12_14_131201_add_unique_datetime_at_k_factors_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('k_factors', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('k_factor_r');
+            $table->double('k_factor_s');
+            $table->double('k_factor_t');
+            $table->double('k_factor')->default(0)->change();
+            $table->double('k_factor_r')->default(0)->change();
+            $table->double('k_factor_s')->default(0)->change();
+            $table->double('k_factor_t')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('k_factors', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+            $table->dropColumn('k_factor_r');
+            $table->dropColumn('k_factor_s');
+            $table->dropColumn('k_factor_t');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_142240_add_unique_datetime_at_temperatures_table.php
+++ b/database/migrations/2024_12_14_142240_add_unique_datetime_at_temperatures_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('temperatures', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('temperature')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('temperatures', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_144825_add_unique_datetime_at_pressures_table.php
+++ b/database/migrations/2024_12_14_144825_add_unique_datetime_at_pressures_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('pressures', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('pressure')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('pressures', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_150814_add_unique_datetime_at_ambient_temperatures_table.php
+++ b/database/migrations/2024_12_14_150814_add_unique_datetime_at_ambient_temperatures_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ambient_temperatures', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('ambient_temperature')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ambient_temperatures', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_152857_add_unique_datetime_at_oil_level_table.php
+++ b/database/migrations/2024_12_14_152857_add_unique_datetime_at_oil_level_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('oil_levels', function (Blueprint $table) {
+            $table->string('datetime')->unique();
+            $table->double('oil_level')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('oil_levels', function (Blueprint $table) {
+            $table->dropColumn('datetime');
+        });
+    }
+};

--- a/database/migrations/2024_12_14_190847_create_ihd_currents_table.php
+++ b/database/migrations/2024_12_14_190847_create_ihd_currents_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ihd_currents', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('trafo_id');
+            $table->string('topic_name');
+            for ($i = 1; $i <= 19; $i += 2) {
+                $table->double("current_r_h$i")->default(0);
+                $table->double("current_s_h$i")->default(0);
+                $table->double("current_t_h$i")->default(0);
+            }
+            $table->timestamps();
+            $table->string('datetime')->unique();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ihd_currents');
+    }
+};

--- a/database/migrations/2024_12_15_035013_create_ihd_voltages_table.php
+++ b/database/migrations/2024_12_15_035013_create_ihd_voltages_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ihd_voltages', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('trafo_id');
+            $table->string('topic_name');
+            for ($i = 1; $i <= 19; $i += 2) {
+                $table->double("voltage_r_h$i")->default(0);
+                $table->double("voltage_s_h$i")->default(0);
+                $table->double("voltage_t_h$i")->default(0);
+            }
+            $table->timestamps();
+            $table->string('datetime')->unique();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ihd_voltages');
+    }
+};

--- a/resources/js/Components/Metric/OrderTableBodyV2.tsx
+++ b/resources/js/Components/Metric/OrderTableBodyV2.tsx
@@ -1,0 +1,18 @@
+import { OrderTableBodyV2Props } from "@/types/component";
+import {TableBody, TableCell, TableRow} from "@mui/material";
+
+export default function OrderTableBodyV2({key, orderName, rValue, sValue, tValue}: OrderTableBodyV2Props) {
+    return <TableBody>
+        <TableRow
+            key={key}
+            sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+        >
+            <TableCell component="th" scope="row">
+                {orderName}
+            </TableCell>
+            <TableCell align="right">{rValue}</TableCell>
+            <TableCell align="right">{sValue}</TableCell>
+            <TableCell align="right">{tValue}</TableCell>
+        </TableRow>
+    </TableBody>
+}

--- a/resources/js/Pages/Chart/ChartIHDV2.tsx
+++ b/resources/js/Pages/Chart/ChartIHDV2.tsx
@@ -1,0 +1,195 @@
+import { ChartIHDProps, ChartIHDPropsV2 } from "@/types/chart";
+import { Box, Container, Grid, Typography } from "@mui/material";
+import { Bar } from "react-chartjs-2";
+import 'chart.js/auto';
+import AppBarTriple from "@/Components/Shared/AppBarTriple";
+import ShowAssignmentIcon from "@mui/icons-material/Assignment";
+import ButtonEndHref from "@/Components/Shared/ButtonEndHref";
+import { rstBarChartString } from "@/helpers/generator/chart-generator";
+import calculateMetrics from "@/helpers/analysis/calculate-metric";
+import AggregationRSTOnly from "@/Components/Chart/AggregationRSTOnly";
+import GoogleMap from "@/Components/Map/GoogleMap";
+
+export default function ChartIHD({
+    trafo,
+    ihdVoltages,
+    ihdCurrents,
+}: ChartIHDPropsV2) {
+    const ihdVoltageR = [
+        ihdVoltages[0]?.voltage_r_h1 ?? 0,
+        ihdVoltages[0]?.voltage_r_h3 ?? 0,
+        ihdVoltages[0]?.voltage_r_h5 ?? 0,
+        ihdVoltages[0]?.voltage_r_h7 ?? 0,
+        ihdVoltages[0]?.voltage_r_h9 ?? 0,
+        ihdVoltages[0]?.voltage_r_h11 ?? 0,
+        ihdVoltages[0]?.voltage_r_h13 ?? 0,
+        ihdVoltages[0]?.voltage_r_h15 ?? 0,
+        ihdVoltages[0]?.voltage_r_h17 ?? 0,
+        ihdVoltages[0]?.voltage_r_h19 ?? 0,
+    ]
+
+    const ihdVoltageS = [
+        ihdVoltages[0]?.voltage_s_h1 ?? 0,
+        ihdVoltages[0]?.voltage_s_h3 ?? 0,
+        ihdVoltages[0]?.voltage_s_h5 ?? 0,
+        ihdVoltages[0]?.voltage_s_h7 ?? 0,
+        ihdVoltages[0]?.voltage_s_h9 ?? 0,
+        ihdVoltages[0]?.voltage_s_h11 ?? 0,
+        ihdVoltages[0]?.voltage_s_h13 ?? 0,
+        ihdVoltages[0]?.voltage_s_h15 ?? 0,
+        ihdVoltages[0]?.voltage_s_h17 ?? 0,
+        ihdVoltages[0]?.voltage_s_h19 ?? 0,
+    ]
+
+    const ihdVoltageT = [
+        ihdVoltages[0]?.voltage_t_h1 ?? 0,
+        ihdVoltages[0]?.voltage_t_h3 ?? 0,
+        ihdVoltages[0]?.voltage_t_h5 ?? 0,
+        ihdVoltages[0]?.voltage_t_h7 ?? 0,
+        ihdVoltages[0]?.voltage_t_h9 ?? 0,
+        ihdVoltages[0]?.voltage_t_h11 ?? 0,
+        ihdVoltages[0]?.voltage_t_h13 ?? 0,
+        ihdVoltages[0]?.voltage_t_h15 ?? 0,
+        ihdVoltages[0]?.voltage_t_h17 ?? 0,
+        ihdVoltages[0]?.voltage_t_h19 ?? 0,
+    ]
+
+    const ihdCurrentR = [
+        ihdCurrents[0]?.current_r_h1 ?? 0,
+        ihdCurrents[0]?.current_r_h3 ?? 0,
+        ihdCurrents[0]?.current_r_h5 ?? 0,
+        ihdCurrents[0]?.current_r_h7 ?? 0,
+        ihdCurrents[0]?.current_r_h9 ?? 0,
+        ihdCurrents[0]?.current_r_h11 ?? 0,
+        ihdCurrents[0]?.current_r_h13 ?? 0,
+        ihdCurrents[0]?.current_r_h15 ?? 0,
+        ihdCurrents[0]?.current_r_h17 ?? 0,
+        ihdCurrents[0]?.current_r_h19 ?? 0,
+    ]
+
+    const ihdCurrentS = [
+        ihdCurrents[0]?.current_s_h1 ?? 0,
+        ihdCurrents[0]?.current_s_h3 ?? 0,
+        ihdCurrents[0]?.current_s_h5 ?? 0,
+        ihdCurrents[0]?.current_s_h7 ?? 0,
+        ihdCurrents[0]?.current_s_h9 ?? 0,
+        ihdCurrents[0]?.current_s_h11 ?? 0,
+        ihdCurrents[0]?.current_s_h13 ?? 0,
+        ihdCurrents[0]?.current_s_h15 ?? 0,
+        ihdCurrents[0]?.current_s_h17 ?? 0,
+        ihdCurrents[0]?.current_s_h19 ?? 0,
+    ]
+
+    const ihdCurrentT = [
+        ihdCurrents[0]?.current_t_h1 ?? 0,
+        ihdCurrents[0]?.current_t_h3 ?? 0,
+        ihdCurrents[0]?.current_t_h5 ?? 0,
+        ihdCurrents[0]?.current_t_h7 ?? 0,
+        ihdCurrents[0]?.current_t_h9 ?? 0,
+        ihdCurrents[0]?.current_t_h11 ?? 0,
+        ihdCurrents[0]?.current_t_h13 ?? 0,
+        ihdCurrents[0]?.current_t_h15 ?? 0,
+        ihdCurrents[0]?.current_t_h17 ?? 0,
+        ihdCurrents[0]?.current_t_h19 ?? 0,
+    ]
+
+    const metricAvgVoltage = rstBarChartString({
+        labels: Array.from({ length: 21 }, (_, i) => `H${i + 1}`),
+        rData: ihdVoltageR,
+        sData: ihdVoltageS,
+        tData: ihdVoltageT,
+    })
+
+    const ihdVoltageRAggregation = calculateMetrics(ihdVoltageR);
+    const ihdVoltageSAggregation = calculateMetrics(ihdVoltageS);
+    const ihdVoltageTAggregation = calculateMetrics(ihdVoltageT);
+
+    const metricAvgCurrent = rstBarChartString({
+        labels: Array.from({ length: 21 }, (_, i) => `H${i + 1}`),
+        rData: ihdCurrentR,
+        sData: ihdCurrentS,
+        tData: ihdCurrentT,
+    })
+
+    const ihdCurrentRAggregation = calculateMetrics(ihdCurrentR);
+    const ihdCurrentSAggregation = calculateMetrics(ihdCurrentS);
+    const ihdCurrentTAggregation = calculateMetrics(ihdCurrentT);
+
+    return (
+        <>
+            <AppBarTriple
+                startText={'Chart IHD'}
+                middleText={trafo.name + ' - ' + trafo.address}
+                endText={"Latest Data"}
+            />
+            <Container maxWidth="xl" sx={{ pt: 8 }}>
+                <ButtonEndHref
+                    href={route('trafo.show', [trafo.id])}
+                    text={'Back to Detail'}
+                    icon={<ShowAssignmentIcon />}
+                    sx={{ mt: 2 }}
+                />
+                <Grid container spacing={2} sx={{ pb: 2 }}>
+                    <Grid item xs={12} md={4}>
+                        <Box
+                            sx={{ px: 2 }}
+                            display="flex"
+                            justifyContent="center"
+                            alignItems="end"
+                            flexDirection="column"
+                        >
+                            <Typography variant={"h6"}>Individual Harmonics Distortion Voltage (IHDv)</Typography>
+                            <Bar data={metricAvgVoltage} />
+                            <Container sx={{ p: 2 }}>
+                                <AggregationRSTOnly
+                                    rMax={ihdVoltageRAggregation.max}
+                                    sMax={ihdVoltageSAggregation.max}
+                                    tMax={ihdVoltageTAggregation.max}
+                                    rAvg={ihdVoltageRAggregation.avg}
+                                    sAvg={ihdVoltageSAggregation.avg}
+                                    tAvg={ihdVoltageTAggregation.avg}
+                                    rMin={ihdVoltageRAggregation.min}
+                                    sMin={ihdVoltageSAggregation.min}
+                                    tMin={ihdVoltageTAggregation.min}
+                                />
+                            </Container>
+                        </Box>
+                    </Grid>
+                    <Grid item xs={12} md={4}>
+                        <Box
+                            sx={{ px: 2 }}
+                            display="flex"
+                            justifyContent="center"
+                            alignItems="end"
+                            flexDirection="column"
+                        >
+                            <Typography variant={"h6"}>Individual Harmonics Distortion Current (IHDi)</Typography>
+                            <Bar data={metricAvgCurrent} />
+                            <Container sx={{ p: 2 }}>
+                                <AggregationRSTOnly
+                                    rMax={ihdCurrentRAggregation.max}
+                                    sMax={ihdCurrentSAggregation.max}
+                                    tMax={ihdCurrentTAggregation.max}
+                                    rAvg={ihdCurrentRAggregation.avg}
+                                    sAvg={ihdCurrentSAggregation.avg}
+                                    tAvg={ihdCurrentTAggregation.avg}
+                                    rMin={ihdCurrentRAggregation.min}
+                                    sMin={ihdCurrentSAggregation.min}
+                                    tMin={ihdCurrentTAggregation.min}
+                                />
+                            </Container>
+                        </Box>
+                    </Grid>
+                    <Grid item xs={12} md={4}>
+                        <GoogleMap
+                            lat={Number(trafo.latitude)}
+                            lng={Number(trafo.longitude)}
+                            title={trafo.name}
+                            height={'700px'}
+                        />
+                    </Grid>
+                </Grid>
+            </Container>
+        </>
+    )
+}

--- a/resources/js/Pages/Metric/MetricIHDV2.tsx
+++ b/resources/js/Pages/Metric/MetricIHDV2.tsx
@@ -1,0 +1,230 @@
+import { MetricIHDV2Props } from "@/types/metric";
+import { Container, Grid, Paper, Table, TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
+import AppBarTriple from "@/Components/Shared/AppBarTriple";
+import ButtonEndHref from "@/Components/Shared/ButtonEndHref";
+import ShowChartIcon from "@mui/icons-material/ShowChart";
+import OrderTableBody from "@/Components/Metric/OrderTableBody";
+import { useState } from "react";
+import TimeNavigator from "@/Components/Metric/TimeNavigator";
+import OrderTableBodyV2 from "@/Components/Metric/OrderTableBodyV2";
+
+export default function MetricIHDV2({
+    trafo,
+    date,
+    ihdCurrents,
+    ihdVoltages
+}: MetricIHDV2Props) {
+    const [currentIndex, setCurrentIndex] = useState((ihdCurrents?.length ?? 0) - 1);
+    const [voltageIndex, setVoltageIndex] = useState((ihdVoltages?.length ?? 0) - 1);
+    return (
+        <>
+            <AppBarTriple
+                startText={'Metric IHD'}
+                middleText={trafo.name + ' - ' + trafo.address}
+                endText={date}
+            />
+            <Container maxWidth="xl" sx={{ pt: 6 }}>
+                <ButtonEndHref
+                    href={route('chart.ihd', [trafo.id])}
+                    text={'Open Chart'}
+                    icon={<ShowChartIcon />}
+                    sx={{ mt: 4 }}
+                />
+                <Grid container spacing={2}>
+                    <Grid item xs={12} md={6}>
+                        <TimeNavigator
+                            timestamp={ihdCurrents[currentIndex]?.created_at || ''}
+                            enableBefore={currentIndex > 0}
+                            enableNext={currentIndex < ihdCurrents.length - 1}
+                            onBefore={() => setCurrentIndex(currentIndex - 1)}
+                            onNext={() => setCurrentIndex(currentIndex + 1)}
+                        ></TimeNavigator>
+                        <TableContainer component={Paper} sx={{ mb: 4 }}>
+                            <Table size='medium'>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell align="center" colSpan={4}>
+                                            Individual Harmonics Distortion Currents (IHDi)
+                                        </TableCell>
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell>Orde</TableCell>
+                                        <TableCell align="right">R</TableCell>
+                                        <TableCell align="right">S</TableCell>
+                                        <TableCell align="right">T</TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h1'}
+                                    orderName={'H1'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h1 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h1 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h1 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h3'}
+                                    orderName={'H3'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h3 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h3 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h3 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h5'}
+                                    orderName={'H5'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h5 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h5 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h5 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h7'}
+                                    orderName={'H7'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h7 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h7 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h7 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h9'}
+                                    orderName={'H9'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h9 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h9 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h9 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h11'}
+                                    orderName={'H11'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h11 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h11 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h11 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h13'}
+                                    orderName={'H13'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h13 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h13 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h13 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h15'}
+                                    orderName={'H15'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h15 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h15 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h15 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h17'}
+                                    orderName={'H17'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h17 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h17 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h17 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.current.h19'}
+                                    orderName={'H19'}
+                                    rValue={ihdCurrents[currentIndex]?.current_r_h19 ?? 0}
+                                    sValue={ihdCurrents[currentIndex]?.current_s_h19 ?? 0}
+                                    tValue={ihdCurrents[currentIndex]?.current_t_h19 ?? 0}
+                                />
+                            </Table>
+                        </TableContainer>
+                    </Grid>
+                    <Grid item xs={12} md={6}>
+                        <TimeNavigator
+                            timestamp={ihdVoltages[voltageIndex]?.created_at || ''}
+                            enableBefore={voltageIndex > 0}
+                            enableNext={voltageIndex < ihdVoltages.length - 1}
+                            onBefore={() => setVoltageIndex(voltageIndex - 1)}
+                            onNext={() => setVoltageIndex(voltageIndex + 1)}
+                        ></TimeNavigator>
+                        <TableContainer component={Paper} sx={{ mb: 4 }}>
+                            <Table size='medium'>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell align="center" colSpan={4}>
+                                            Individual Harmonics Distortion Voltages (IHDv)
+                                        </TableCell>
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell>Orde</TableCell>
+                                        <TableCell align="right">R</TableCell>
+                                        <TableCell align="right">S</TableCell>
+                                        <TableCell align="right">T</TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h1'}
+                                    orderName={'H1'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h1 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h1 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h1 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h3'}
+                                    orderName={'H3'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h3 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h3 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h3 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h5'}
+                                    orderName={'H5'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h5 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h5 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h5 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h7'}
+                                    orderName={'H7'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h7 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h7 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h7 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h9'}
+                                    orderName={'H9'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h9 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h9 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h9 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h11'}
+                                    orderName={'H11'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h11 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h11 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h11 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h13'}
+                                    orderName={'H13'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h13 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h13 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h13 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h15'}
+                                    orderName={'H15'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h15 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h15 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h15 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h17'}
+                                    orderName={'H17'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h17 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h17 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h17 ?? 0}
+                                />
+                                <OrderTableBodyV2
+                                    key={'ihd.voltage.h19'}
+                                    orderName={'H19'}
+                                    rValue={ihdVoltages[voltageIndex]?.voltage_r_h19 ?? 0}
+                                    sValue={ihdVoltages[voltageIndex]?.voltage_s_h19 ?? 0}
+                                    tValue={ihdVoltages[voltageIndex]?.voltage_t_h19 ?? 0}
+                                />
+                            </Table>
+                        </TableContainer>
+                    </Grid>
+                </Grid>
+            </Container>
+        </>
+    )
+}

--- a/resources/js/Pages/Metric/MetricPKA.tsx
+++ b/resources/js/Pages/Metric/MetricPKA.tsx
@@ -16,7 +16,9 @@ export default function MetricPKA({trafo, date, powerLosses, kFactors, triplenCu
     const columnsKFactor: GridColDef[] = [
         { field: 'id', headerName: 'ID'},
         { field: 'createdAt', headerName: 'Date', width: 200},
-        { field: 'k_factor', headerName: 'K Factor'},
+        { field: 'k_factor_r', headerName: 'R'},
+        { field: 'k_factor_s', headerName: 'S'},
+        { field: 'k_factor_t', headerName: 'T'},
     ]
 
     const columnsTriplenCurrent: GridColDef[] = [
@@ -37,7 +39,9 @@ export default function MetricPKA({trafo, date, powerLosses, kFactors, triplenCu
         return {
             id: kFactor.id,
             createdAt: new Date(kFactor.created_at).toLocaleString(),
-            k_factor: kFactor.k_factor,
+            k_factor_r: kFactor.k_factor_r,
+            k_factor_s: kFactor.k_factor_s,
+            k_factor_t: kFactor.k_factor_t,
         }
     });
 

--- a/resources/js/types/chart.d.ts
+++ b/resources/js/types/chart.d.ts
@@ -4,7 +4,7 @@ import {
     Metric, MetricApparentPower,
     MetricCurrent,
     MetricFrequency,
-    MetricHD, MetricKFactor, MetricPower, MetricPowerFactor, MetricPowerLoss, MetricReactivePower,
+    MetricHD, MetricIHDCurrentV2, MetricIHDVoltageV2, MetricKFactor, MetricPower, MetricPowerFactor, MetricPowerLoss, MetricReactivePower,
     MetricTHDCurrent,
     MetricTHDVoltage, MetricTriplenCurrent,
     MetricVoltage, OilLevel, Pressure, Temperature
@@ -99,6 +99,12 @@ export type ChartIHDProps = PageProps & {
     avgCurrentR: number;
     avgCurrentS: number;
     avgCurrentT: number;
+}
+
+export type ChartIHDPropsV2 = PageProps & {
+    trafo: TrafoV1;
+    ihdVoltages: MetricIHDVoltageV2[];
+    ihdCurrents: MetricIHDCurrentV2[];
 }
 
 export type ChartTPOProps = PageProps & {

--- a/resources/js/types/component.d.ts
+++ b/resources/js/types/component.d.ts
@@ -22,6 +22,14 @@ export type OrderTableBodyProps = Props & {
     order: Order;
 }
 
+export type OrderTableBodyV2Props = Props & {
+    key: React.Key;
+    orderName: string;
+    rValue: number;
+    sValue: number;
+    tValue: number;
+}
+
 export type GaugeGroupProps = Props & {
     gauges: number[][]
     labels: string[],

--- a/resources/js/types/metric.d.ts
+++ b/resources/js/types/metric.d.ts
@@ -62,6 +62,9 @@ export interface MetricPowerLoss extends Metric {
 
 export interface MetricKFactor extends Metric {
     k_factor: number;
+    k_factor_r: number;
+    k_factor_s: number;
+    k_factor_t: number;
 }
 
 export interface MetricTriplenCurrent extends Metric {

--- a/resources/js/types/metric.d.ts
+++ b/resources/js/types/metric.d.ts
@@ -1,4 +1,4 @@
-import {PageProps, TrafoV1} from "@/types/index";
+import { PageProps, TrafoV1 } from "@/types/index";
 
 export interface Metric {
     id: number;
@@ -125,6 +125,74 @@ export interface MetricHD extends Metric {
     h21: Order;
 }
 
+export interface MetricIHDCurrentV2 extends Metric {
+    current_r_h1: number;
+    current_s_h1: number;
+    current_t_h1: number;
+    current_r_h3: number;
+    current_s_h3: number;
+    current_t_h3: number;
+    current_r_h5: number;
+    current_s_h5: number;
+    current_t_h5: number;
+    current_r_h7: number;
+    current_s_h7: number;
+    current_t_h7: number;
+    current_r_h9: number;
+    current_s_h9: number;
+    current_t_h9: number;
+    current_r_h11: number;
+    current_s_h11: number;
+    current_t_h11: number;
+    current_r_h13: number;
+    current_s_h13: number;
+    current_t_h13: number;
+    current_r_h15: number;
+    current_s_h15: number;
+    current_t_h15: number;
+    current_r_h17: number;
+    current_s_h17: number;
+    current_t_h17: number;
+    current_r_h19: number;
+    current_s_h19: number;
+    current_t_h19: number;
+    datetime: string;
+}
+
+export interface MetricIHDVoltageV2 extends Metric {
+    voltage_r_h1: number;
+    voltage_s_h1: number;
+    voltage_t_h1: number;
+    voltage_r_h3: number;
+    voltage_s_h3: number;
+    voltage_t_h3: number;
+    voltage_r_h5: number;
+    voltage_s_h5: number;
+    voltage_t_h5: number;
+    voltage_r_h7: number;
+    voltage_s_h7: number;
+    voltage_t_h7: number;
+    voltage_r_h9: number;
+    voltage_s_h9: number;
+    voltage_t_h9: number;
+    voltage_r_h11: number;
+    voltage_s_h11: number;
+    voltage_t_h11: number;
+    voltage_r_h13: number;
+    voltage_s_h13: number;
+    voltage_t_h13: number;
+    voltage_r_h15: number;
+    voltage_s_h15: number;
+    voltage_t_h15: number;
+    voltage_r_h17: number;
+    voltage_s_h17: number;
+    voltage_t_h17: number;
+    voltage_r_h19: number;
+    voltage_s_h19: number;
+    voltage_t_h19: number;
+    datetime: string;
+}
+
 export interface Temperature extends Metric {
     temperature: number;
 }
@@ -170,6 +238,13 @@ export type MetricIHDProps = PageProps & {
     date: string;
     ihdCurrents: MetricHD[];
     ihdVoltages: MetricHD[];
+}
+
+export type MetricIHDV2Props = PageProps & {
+    trafo: TrafoV1;
+    date: string;
+    ihdCurrents: MetricIHDCurrentV2[];
+    ihdVoltages: MetricIHDVoltageV2[];
 }
 
 export type MetricTPOProps = PageProps & {

--- a/routes/web.php
+++ b/routes/web.php
@@ -94,7 +94,7 @@ Route::prefix('chart')->middleware(['auth'])->group(function () {
         ->name('chart.pqspf');
     Route::get('/{trafoid}/thd-ihd', ChartTHDController::class)
         ->name('chart.thd-ihd');
-    Route::get('/{trafoid}/ihd', [ChartController::class, 'getChartIHD'])
+    Route::get('/{trafoid}/ihd', [ChartController::class, 'getChartIHDV2'])
         ->name('chart.ihd');
     Route::get('/{trafoid}/tpo', ChartTPOController::class)
         ->name('chart.tpo');

--- a/routes/web.php
+++ b/routes/web.php
@@ -77,7 +77,7 @@ Route::prefix('metric')->middleware(['auth'])->group(function () {
         ->name('metric.pqspf');
     Route::get('/{trafoid}/{date}/thd-ihd', [MetricController::class, 'getMetricTHDIHD'])
         ->name('metric.thd-ihd');
-    Route::get('/{trafoid}/{date}/ihd', [MetricController::class, 'getMetricIHD'])
+    Route::get('/{trafoid}/{date}/ihd', [MetricController::class, 'getMetricIHDV2'])
         ->name('metric.ihd');
     Route::get('/{trafoid}/{date}/tpo', [MetricController::class, 'getMetricTPO'])
         ->name('metric.tpo');


### PR DESCRIPTION
This pull request introduces several updates to the `ChartController` and `MetricController` classes, adds new models for IHDCurrentV2 and IHDVoltageV2, and includes changes to multiple existing models to add a `datetime` field. Additionally, it includes new migration files to update the database schema.

### Controller Updates:
* Added new methods `getChartIHDV2` and `getMetricIHDV2` to `ChartController` and `MetricController` respectively, enabling the retrieval of data for the new V2 models. [[1]](diffhunk://#diff-df194b6152ad0de8c222bbf70ef786af9a15baa03638ea1b238cfcb1720500acR71-R86) [[2]](diffhunk://#diff-9e6fb9a36a9ad33771b7c8c63c22fc393872bcca38c3f84ee21658ba9cc25b98R127-R144)

### Model Updates:
* Added new models `IHDCurrentV2` and `IHDVoltageV2` with corresponding fields to handle the new data structure. [[1]](diffhunk://#diff-ca0853b9779d80888db74b4e7f4a927e7db56c31c9acc527f1ee65c2bacb43c2R1-R49) [[2]](diffhunk://#diff-d10dbf04e87d1036eae10130558887064484ee553b8e4b8c47af719196b5a132R1-R49)
* Updated existing models to include a `datetime` field in the `fillable` array to track the timestamp of the data. This change affects multiple models including `AmbientTemperature`, `ApparentPower`, `Current`, `Frequency`, `KFactor`, `OilLevel`, `Power`, `PowerFactor`, `Pressure`, `ReactivePower`, `THDCurrent`, `THDVoltage`, `Temperature`, and `Voltage`. [[1]](diffhunk://#diff-63884619b0d04978aa09bb0bc949aa843463a0a0d97ec8963636bb0cf5a99687R16) [[2]](diffhunk://#diff-d5169898d272f7e7dacf90d69f002a415ee7cdcd4727428749b7497e38c5d840R11-R19) [[3]](diffhunk://#diff-74382ee0ff8af5dbee7328763be9e38e9653cfb228842f2b0d72274f884612f6R19) [[4]](diffhunk://#diff-bc3b6715979958629ba24739b42fb785524e9bd7ee73ff8503941ddc89dad055R18) [[5]](diffhunk://#diff-fb39518a1640dddbbaf7232ddeeadbd97b29c871fee9862a5e0a35b402ff621bR11-R19) [[6]](diffhunk://#diff-98c461ce3ceaf3e5a7f0f69afe9906772589826384feddeeb5fc0bac6ccf40e5R16) [[7]](diffhunk://#diff-130b9864243a105e82954c78fefe979feff24fcfffe405789a4791c4f6bcf29bR11-R19) [[8]](diffhunk://#diff-7e8e0aa22de0a67d972ff8bb1c3e7a6207dabddaa351ce0fb91550a4601bd58eR11-R19) [[9]](diffhunk://#diff-59fb3c40393a32178afbce5f37d9d2f0f43d0913c10adbfc5835ef778c4c5968R16) [[10]](diffhunk://#diff-286d82c4d52fdb6a60b8b3f41d989a9b47a49854c5128a1798266f5c109a8af2R11-R18) [[11]](diffhunk://#diff-73274c8e3254dcb8ab3fef27f73673e91594248f716a4b4bbb9e3505e601b676R18) [[12]](diffhunk://#diff-2d585fe1b0e011cce98bb7ad4ad0dee5e9005effb5af16a56c3397eebc38d26cR18) [[13]](diffhunk://#diff-a0a0fbf0c66329ff9a8ffdb8a2ccb454c593b48ff3195f9e7db0dae179670dbdR16) [[14]](diffhunk://#diff-69b4b280514c4a1bf276394c276528c920d25e4e6cbde96929ef7d5d406157f3R18)

### Migration Updates:
* Added new migration files to update the `voltages` and `currents` tables by adding a unique `datetime` column and setting default values for existing columns. [[1]](diffhunk://#diff-76c632fdcf3fc755d9f19e8be886e4ffc0d3f170d9bf949a32844fecb3650f97R1-R31) [[2]](diffhunk://#diff-0523a7e0437f708da833614da453a17e4984eb6b9a058398d47c720f39488631R1-R32)
